### PR TITLE
less generic command

### DIFF
--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 
 function usage() {
   console.error('');
-  console.error('Usage: migrate <method> <database> <script>');
+  console.error('Usage: dynamodb-migrate <method> <database> <script>');
   console.error('');
   console.error('method: either scan or stream to read records from the database or from stdin, respectively');
   console.error('database: region/name of the database to work against');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tape test/*.test.js"
   },
   "bin": {
-    "migrate": "bin/migrate.js"
+    "dynamo-migrate": "bin/migrate.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tape test/*.test.js"
   },
   "bin": {
-    "dynamo-migrate": "bin/migrate.js"
+    "dynamodb-migrate": "bin/migrate.js"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Scan mode is where the database is scanned and your migration script will be fed
 Run your migration without impacting any records to check that your conditions are filtering as you expect them to. Remember that your migration script *will not* receive a dyno object in this case.
 
 ```
-$ migrate scan us-east-1/my-table ./my-migration-script.js
+$ dynamodb-migrate scan us-east-1/my-table ./my-migration-script.js
 ```
 
 When the migration is complete, it will print the paths to your info and error logs.
@@ -62,13 +62,13 @@ When the migration is complete, it will print the paths to your info and error l
 Specify the `--live` flag to run the migration once and for all.
 
 ```
-$ migrate scan us-east-1/my-table ./my-migration-script.js --live
+$ dynamodb-migrate scan us-east-1/my-table ./my-migration-script.js --live
 ```
 
 ## Help
 
 ```
-Usage: migrate <method> <database> <script>
+Usage: dynamodb-migrate <method> <database> <script>
 
 method: either scan or stream to read records from the database or from stdin, respectively
 database: region/name of the database to work against


### PR DESCRIPTION
running `migrate` from anywhere is scary :) 

`dynamodb-migrate` seems a little better scoped. that ok @rclark?
