### PR TITLE
pass dyno to migrate.finish

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function(method, database, migrate, stream, live, concurrency, 
     .pipe(migrator)
       .on('error', callback)
       .on('finish', function() {
-        if (migrate.finish) migrate.finish(migrator.log, done);
+        if (migrate.finish) migrate.finish(dyno, migrator.log, done);
         else done();
 
         function done() {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function(method, database, migrate, stream, live, concurrency, 
     .pipe(migrator)
       .on('error', callback)
       .on('finish', function() {
-        if (migrate.finish) migrate.finish(dyno, migrator.log, done);
+        if (migrate.finish) migrate.finish(live ? dyno : null, migrator.log, done);
         else done();
 
         function done() {

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ module.exports = function(record, dyno, logger, callback) {
   });
 }
 
-module.exports.finish = function(logger, callback) {
+module.exports.finish = function(dyno, logger, callback) {
   logger.info('Deleted %s records', deleted);
   callback();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,8 +31,9 @@ dynamodb.test('[index] live scan', fixtures, function(assert) {
     }, 300);
   }
 
-  migrate.finish = function(logger, callback) {
+  migrate.finish = function(dyno, logger, callback) {
     gotLogger = true;
+    assert.ok(dyno, 'finish function received dyno');
     callback();
   };
 


### PR DESCRIPTION
`migrate.finish` should receive dyno in order to wrap up any final reads and writes. 

/cc @rclark 
