### PR TITLE
expect dynamo wire format instead of JSON

### DIFF
--- a/lib/aggregator.js
+++ b/lib/aggregator.js
@@ -1,4 +1,5 @@
 var stream = require('stream');
+var Dyno = require('dyno');
 
 module.exports = function(concurrency, objectMode) {
   var items = [];
@@ -11,7 +12,7 @@ module.exports = function(concurrency, objectMode) {
     if (Buffer.isBuffer(item)) item = item.toString('utf8');
     if (!item) return callback();
 
-    item = typeof item === 'string' ? JSON.parse(item) : item;
+    item = typeof item === 'string' ? Dyno.deserialize(item) : item;
     for (var key in item) {
       if (typeof item[key] === 'string' && item[key].indexOf('base64:') === 0) {
         item[key] = new Buffer(item[key].split('base64:')[1], 'base64');

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "underscore": "^1.8.3"
   },
   "dependencies": {
-    "dyno": "^0.13.1",
+    "dyno": "0.15.1",
     "minimist": "^1.1.1",
     "queue-async": "^1.0.7",
     "split": "^0.3.3"

--- a/test/aggregator.test.js
+++ b/test/aggregator.test.js
@@ -1,6 +1,7 @@
 var test = require('tape');
 var _ = require('underscore');
 var Aggregator = require('../lib/aggregator');
+var Dyno = require('dyno');
 
 test('[aggregator] objects', function(assert) {
   var aggregator = Aggregator(1, true);
@@ -50,7 +51,7 @@ test('[aggregator] strings', function(assert) {
   });
 
   _.range(30).forEach(function(i) {
-    aggregator.write(JSON.stringify({
+    aggregator.write(Dyno.serialize({
       data: 'base64:' + (new Buffer(i.toString())).toString('base64')
     }));
   });


### PR DESCRIPTION
- Bump dyno to 0.15.1
- Aggregator should expect wire-format; use `Dyno.deserialize` instead of `JSON.parse`
- Update corresponding test

/cc @rclark 
