### PR TITLE
kinesis config with multiple properties in key

### DIFF
--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -14,7 +14,7 @@ function usage() {
   console.error('script: relative path to a migration script');
   console.error('');
   console.error('Options:');
-  console.error(' - stream: region/name/key/key specifying region, name and keys for replication kinesis stream');
+  console.error(' - stream: region/name/key specifying region, name and keys (keys may be comma separated for multiple properties) for replication kinesis stream');
   console.error(' - concurrency [1]: number of records to process in parallel');
   console.error(' - live [false]: if not specified, the migration script will not receive a database reference');
 }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(method, database, migrate, stream, live, concurrency, 
       params.kinesisConfig.secretAccessKey = 'fake';
       params.kinesisConfig.endpoint = 'http://localhost:7654';
     }
-}
+  }
 
   var dyno = Dyno(params);
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(method, database, migrate, stream, live, concurrency, 
     params.kinesisConfig = {
       stream: stream.split('/')[1],
       region: stream.split('/')[0],
-      key: stream.split('/').slice(2)
+      key: stream.split('/')[2].split(',')
     };
 
     if (stream.split('/')[0] === 'local') {
@@ -31,7 +31,7 @@ module.exports = function(method, database, migrate, stream, live, concurrency, 
       params.kinesisConfig.secretAccessKey = 'fake';
       params.kinesisConfig.endpoint = 'http://localhost:7654';
     }
-  }
+}
 
   var dyno = Dyno(params);
 

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,13 @@ Specify the `--live` flag to run the migration once and for all.
 $ dynamodb-migrate scan us-east-1/my-table ./my-migration-script.js --live
 ```
 
+### Write to a kinesis stream
+
+` --stream region/streamName/key`
+
+To write records to a kinesis stream for replication, `--stream` may be passed as an option. `region`, `stream name`, and `key` should be given as `/`-separated arguments in that order. `key` may contain multiple properties, separated by a comma (e.g. `region/streamName/id,collection`).
+
+
 ## Help
 
 ```

--- a/test/table2.json
+++ b/test/table2.json
@@ -1,0 +1,16 @@
+{
+    "TableName": "test2",
+    "AttributeDefinitions": [
+        {"AttributeName": "id", "AttributeType": "S"},
+        {"AttributeName": "collection", "AttributeType": "S"}
+    ],
+    "KeySchema": [
+        {"AttributeName": "collection", "KeyType": "HASH"},
+        {"AttributeName": "id", "KeyType": "RANGE"}
+    ],
+    "ProvisionedThroughput": {
+        "ReadCapacityUnits": 1,
+        "WriteCapacityUnits": 1
+    }
+}
+


### PR DESCRIPTION
Options for `--stream` currently accept `key` as a single string.

```
--stream region/streamName/key
```

This change allows multiple properties to be passed into `key` separated by a comma:

```
--stream region/streamName/prop1,prop2
```

This adds support for a key that contains multiple properties (e.g. `'id'` and `'collection'`). If passed into `--stream` as `region/streamName/id,collection`, the resulting kinesis configuration will contain `key: ['id', 'collection' ]`

Oh, and tests... once I can get them to work :)

hai @rclark 
