### PR TITLE
Upgrade to dyno@1.0.1

### DIFF
--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -14,7 +14,6 @@ function usage() {
   console.error('script: relative path to a migration script');
   console.error('');
   console.error('Options:');
-  console.error(' - stream: region/name/key specifying region, name and keys (keys may be comma separated for multiple properties) for replication kinesis stream');
   console.error(' - concurrency [1]: number of records to process in parallel');
   console.error(' - live [false]: if not specified, the migration script will not receive a database reference');
   console.error(' - dyno [false]: if not specified, it is assumed that the objects are formatted using standard DynamoDB syntax. Pass the `--dyno` flag to the migrator if your input JSON objects are in a format suitable for direct usage in dyno (https://github.com/mapbox/dyno)');
@@ -52,7 +51,6 @@ var options = {
   method: method,
   database: database,
   migrate: migrate,
-  stream: args.stream,
   live: args.live,
   plainJSON: args.dyno,
   concurrency: args.concurrency || 1,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/mapbox/dynamodb-migrator#readme",
   "devDependencies": {
     "dynamodb-test": "^0.2.0",
-    "kinesis-test": "^1.0.1",
     "tape": "^4.5.1",
     "underscore": "^1.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   },
   "homepage": "https://github.com/mapbox/dynamodb-migrator#readme",
   "devDependencies": {
-    "dynamodb-test": "0.0.4",
-    "kinesis-test": "0.0.2",
-    "tape": "^3.5.0",
+    "dynamodb-test": "^0.2.0",
+    "kinesis-test": "^1.0.1",
+    "tape": "^4.5.1",
     "underscore": "^1.8.3"
   },
   "dependencies": {
-    "dyno": "0.15.1",
-    "minimist": "^1.1.1",
+    "dyno": "^1.0.1",
+    "minimist": "^1.2.0",
     "queue-async": "1.0.7",
     "split": "^0.3.3"
   }

--- a/readme.md
+++ b/readme.md
@@ -67,12 +67,6 @@ If you're running in stream mode from something like a prior database dump, you 
     $ dynamodb-filter ./some-dump.gz ./my-script.js --output ./some-filtered-dump.gz
     ```
 
-### Write to a kinesis stream
-
-` --stream region/streamName/key`
-
-To write records to a kinesis stream for replication, `--stream` may be passed as an option. `region`, `stream name`, and `key` should be given as `/`-separated arguments in that order. `key` may contain multiple properties, separated by a comma (e.g. `region/streamName/id,collection`).
-
 ### Specify type of JSON
 
 Pass the `--dyno` flag to the migrator if your input JSON objects are in a format suitable for direct usage in [dyno](https://github.com/mapbox/dyno). Otherwise, it is assumed that the objects are formatted using standard DynamoDB syntax.
@@ -107,7 +101,6 @@ database: region/name of the database to work against
 script: relative path to a migration script
 
 Options:
- - stream: region/name/key specifying region, name and keys (keys may be comma separated for multiple properties) for replication kinesis stream
  - concurrency [1]: number of records to process in parallel
  - live [false]: if not specified, the migration script will not receive a database reference
  - dyno [false]: if not specified, it is assumed that the objects are formatted using standard DynamoDB syntax. Pass the `--dyno` flag to the migrator if your input JSON objects are in a format suitable for direct usage in dyno (https://github.com/mapbox/dyno)


### PR DESCRIPTION
Breaking changes: 
- passes migration scripts a dyno v1.x client
- drops support for writing to a kinesis stream alongside the migration

cc @emilymcafee this was shockingly easy
