### PR TITLE
Add configurable endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -54,7 +54,8 @@ var options = {
   live: args.live,
   plainJSON: args.dyno,
   concurrency: args.concurrency || 1,
-  rateLogging: args.rate
+  rateLogging: args.rate,
+  endpoint: args.endpoint || 'http://localhost:4567'
 };
 
 migration(options, function(err) {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function(options, callback) {
   var plainJSON = options.plainJSON;
   var concurrency = options.concurrency;
   var rateLogging = options.rateLogging;
+  var endpoint = options.endpoint;
 
   require('http').globalAgent.maxSockets = 5 * concurrency;
   require('https').globalAgent.maxSockets = 5 * concurrency;
@@ -26,7 +27,7 @@ module.exports = function(options, callback) {
   if (region === 'local') {
     params.accessKeyId = 'fake';
     params.secretAccessKey = 'fake';
-    params.endpoint = 'http://localhost:4567';
+    params.endpoint = endpoint;
   }
 
   var dyno = Dyno(params);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,7 +45,8 @@ dynamodb.test('[index] live scan', fixtures, function(assert) {
     live: true,
     plainJSON: false,
     concurrency: 10,
-    rateLogging: false
+    rateLogging: false,
+    endpoint: 'http://localhost:4567'
   };
 
   migration(options, function(err, logpath) {
@@ -86,7 +87,8 @@ dynamodb.test('[index] test-mode with user-provided stream', fixtures, function(
     live: true,
     plainJSON: false,
     concurrency: 10,
-    rateLogging: false
+    rateLogging: false,
+    endpoint: 'http://localhost:4567'
   };
 
   migration(options, function(err, logpath) {
@@ -136,7 +138,8 @@ dynamodb.test('[index] test-mode with user-provided stream that needs splitting'
     live: true,
     plainJSON: false,
     concurrency: 10,
-    rateLogging: false
+    rateLogging: false,
+    endpoint: 'http://localhost:4567'
   };
 
   migration(options, function(err, logpath) {


### PR DESCRIPTION
Enables passing --endpoint option. This is useful when working with alternative dynamo runtimes like Localstack.